### PR TITLE
Fix for issue 79: https://github.com/quarkiverse/quarkus-logging-logb…

### DIFF
--- a/impl/deployment/src/main/java/io/quarkiverse/logging/logback/deployment/LoggingLogbackProcessor.java
+++ b/impl/deployment/src/main/java/io/quarkiverse/logging/logback/deployment/LoggingLogbackProcessor.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -236,7 +238,17 @@ class LoggingLogbackProcessor {
     }
 
     private URL getUrl() {
-        URL url = Loader.getResource(ContextInitializer.TEST_AUTOCONFIG_FILE, Thread.currentThread().getContextClassLoader());
+        ContextInitializer contextInitializer = new ContextInitializer(new LoggerContext());
+        URL url = contextInitializer.findURLOfDefaultConfigurationFile(true);
+        if (url != null) {
+            // Check that file exists at URL
+            if (Files.notExists(Paths.get(url.getPath()))) {
+                log.warn("Logback configuration file not found at " + url + ", using default configuration");
+            } else {
+                return url;
+            }
+        }
+        url = Loader.getResource(ContextInitializer.TEST_AUTOCONFIG_FILE, Thread.currentThread().getContextClassLoader());
         if (url != null) {
             return url;
         }


### PR DESCRIPTION
…ack/issues/79

This solution allows the logback file to be set via system property. 

As mentionned in the issue, according to the docs it should work: 
https://logback.qos.ch/manual/configuration.html#configFileProperty

BUT this documentation assumes that we are using logback-classic and -core with version >= 1.3.0-beta1. The mentioned DefaultJoranConfigurator exists only on these versions.  We are currently using version 1.2.11

This is only a temporary fix! I think it would be nice to update the logback-classic and core versions + make the necessary adaptations.

Nevertheless it would be nice to have this approved to be used!