### PR TITLE
Use `graal-sdk` instead of `svm`

### DIFF
--- a/impl/runtime/pom.xml
+++ b/impl/runtime/pom.xml
@@ -15,8 +15,8 @@
       <artifactId>quarkus-arc</artifactId>
     </dependency>
     <dependency>
-        <groupId>org.graalvm.nativeimage</groupId>
-        <artifactId>svm</artifactId>
+        <groupId>org.graalvm.sdk</groupId>
+        <artifactId>graal-sdk</artifactId>
         <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
- Caused by https://github.com/quarkusio/quarkus/pull/34145